### PR TITLE
Add webhook forwarding worker with KV and D1 logging

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -1,0 +1,12 @@
+CREATE TABLE IF NOT EXISTS logs (
+  id TEXT PRIMARY KEY,
+  endpoint TEXT,
+  ts TEXT,
+  req_method TEXT,
+  req_headers TEXT,
+  req_body TEXT,
+  res_status INTEGER,
+  res_headers TEXT,
+  res_body TEXT
+);
+

--- a/src/pages/[id].ts
+++ b/src/pages/[id].ts
@@ -1,0 +1,75 @@
+import type { PagesFunction } from "astro";
+
+interface Env {
+  ENDPOINTS: KVNamespace;
+  LOGS: D1Database;
+}
+
+function toBase64(buffer: ArrayBuffer): string {
+  let binary = "";
+  const bytes = new Uint8Array(buffer);
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]);
+  }
+  return btoa(binary);
+}
+
+export const onRequest: PagesFunction<Env> = async ({ request, env, params }) => {
+  const id = params.id;
+  if (!id) return new Response("Not found", { status: 404 });
+  const encoded = await env.ENDPOINTS.get(id);
+  if (!encoded) return new Response("Endpoint not found", { status: 404 });
+  const target = atob(encoded);
+
+  const reqBody = await request.clone().arrayBuffer();
+  const logId = crypto.randomUUID();
+  const ts = new Date().toISOString();
+  await env.LOGS.prepare(
+    "INSERT INTO logs (id, endpoint, ts, req_method, req_headers, req_body) VALUES (?, ?, ?, ?, ?, ?)"
+  )
+    .bind(
+      logId,
+      id,
+      ts,
+      request.method,
+      JSON.stringify([...request.headers]),
+      toBase64(reqBody)
+    )
+    .run();
+
+  const forwardReq = new Request(target, {
+    method: request.method,
+    headers: request.headers,
+    body: reqBody,
+    redirect: "manual",
+  });
+
+  let response: Response;
+  try {
+    response = await fetch(forwardReq);
+  } catch (err: any) {
+    await env.LOGS.prepare(
+      "UPDATE logs SET res_status = ?, res_headers = ?, res_body = ? WHERE id = ?"
+    )
+      .bind(500, JSON.stringify({ error: String(err) }), "", logId)
+      .run();
+    return new Response("Upstream error", { status: 502 });
+  }
+
+  const resBody = await response.clone().arrayBuffer();
+  await env.LOGS.prepare(
+    "UPDATE logs SET res_status = ?, res_headers = ?, res_body = ? WHERE id = ?"
+  )
+    .bind(
+      response.status,
+      JSON.stringify([...response.headers]),
+      toBase64(resBody),
+      logId
+    )
+    .run();
+
+  return new Response(resBody, {
+    status: response.status,
+    headers: response.headers,
+  });
+};

--- a/src/pages/register.ts
+++ b/src/pages/register.ts
@@ -1,0 +1,19 @@
+import type { PagesFunction } from "astro";
+
+interface Env {
+  ENDPOINTS: KVNamespace;
+}
+
+export const onRequestPost: PagesFunction<Env> = async ({ request, env }) => {
+  const data = await request.json().catch(() => null);
+  const target = data?.url;
+  if (!target) {
+    return new Response("missing url", { status: 400 });
+  }
+  const id = crypto.randomUUID();
+  const encoded = btoa(target);
+  await env.ENDPOINTS.put(id, encoded);
+  return new Response(JSON.stringify({ endpoint: `/${id}` }), {
+    headers: { "content-type": "application/json" },
+  });
+};


### PR DESCRIPTION
## Summary
- add `/register` endpoint to create webhook forwarding paths in KV
- forward requests via dynamic route that logs request/response lifecycle to D1
- define D1 schema for replayable webhook logs

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_6898f3749c048328976d1e3861a0eaa8